### PR TITLE
Edit "Quick start" in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,16 @@ Prereqs (tested with): Rust 1.88.0, Cargo 1.88.0, Solana CLI 2.2.20 (Agave), Nod
     solana airdrop 2
     ```
 
-    Wallet locations used by this repo  
-    Anchor uses the wallet in Anchor.toml:  
-    [provider] wallet = "~/.config/solana/id.json" (default in this repo)  
-    Client SDK (examples/cli-chat/src/utils/sdk.ts) resolves the wallet in this order:  
-    ANCHOR_WALLET → SOLANA_KEYPAIR → ~/.config/solana/id.json (default)
+    By default, both Anchor and the TypeScript CLI use the same Solana keypair at:
+    - `~/.config/solana/id.json`
+
+    You only need to do something here if you want to use a different keypair:
+    For the CLI demo, set one of (example):
+     - `ANCHOR_WALLET=/path/to/keypair.json`
+     - `SOLANA_KEYPAIR=/path/to/keypair.json`
+
+    For Anchor, edit `Anchor.toml`:
+     - `[provider].wallet = "/path/to/keypair.json"`
 
 2. **Run the pinned devnet demo (no build/deploy needed)**
 
@@ -92,12 +97,20 @@ Prereqs (tested with): Rust 1.88.0, Cargo 1.88.0, Solana CLI 2.2.20 (Agave), Nod
     npm --prefix examples/cli-chat run receive 
     ```
 
+    **Expected output (success):**  
+    `finalize` prints two successful steps (`step-1 done` and `step-2 done`) and shows consumed CU for each transaction.  
+    `receive` ends with:
+      - `PLAINTEXT = Hello world!`
+      - `receive ✅`
+    
     Notes:
     - The SDK reads `fixed/idl/stark_pqc_verifier.json` and `fixed/types/stark_pqc_verifier.ts` by default.
     - The devnet program id is taken from the IDL’s metadata.address.
     - The commands above still build client-side crates during npm run setup.
 
 ### Use your own deployment (Optional)
+
+**Goal:** run the CLI demo against *your* deployed program instead of the pinned devnet deployment in `fixed/`.
 
 ```
 anchor build


### PR DESCRIPTION
@jotaro-yano I attempted to run through the quick start. Going over the steps I ran into some issues:

* I was missing solana, and had some issue locating the right installation URL 
  &rarr; fix: added a link in the readme
  
* Some commands include "(or ...)" , which make the commands non-executable 
  &rarr; fix:  commands can now be copied and executed as-is
  
* Code, paths and plaintext is using same style, reducing legibility 
  &rarr; fix: added some backticks to visually separate code/commands from plaintext 


